### PR TITLE
Now you can set Drupal version non-interactively with site:new

### DIFF
--- a/src/Command/SiteNewCommand.php
+++ b/src/Command/SiteNewCommand.php
@@ -42,7 +42,7 @@ class SiteNewCommand extends Command
         $version = $input->getArgument('version');
 
         if ($version) {
-            $release_selected = '8.x-' . $version;
+            $release_selected = $version;
         } else {
             // Getting Module page header and parse to get module Node
             $output->writeln('[+] <info>' . sprintf($this->trans('commands.site.new.messages.getting-releases')) . '</info>');


### PR DESCRIPTION
When I install my site with the site:new command and set the desired version on Drupal it did not work properly. 

```
$ drupal help site:new
Usage:
  site:new <site-name> [<version>]
```

So I wrote:

```
drupal site:new site_name 8.0.0-beta14
```

and it turned out:

```
$ drupal site:new new_site_name 8.0.0-beta14
[+] Extracting files for Drupal **8.x**-8.0.0-beta14
[+] Client error: 404

 The command was executed succesfully! 
```

It didn't download anything.

I've seen the "8.x" prefix and located it on the code. It was in src/Command/SiteNewCommand.php:

```
if ($version) {
            $release_selected = '8.x' . $version;
        } else {
```

I've changed it:

```
if ($version) {
            $release_selected = '$version;
        } else {
```

now it worked

```
$ php /path_to_drupal_console_sources/bin/console site:new new_site_name 8.0.0-beta14
```

However, I couldn't build the phar file. I could start it only from sources.
